### PR TITLE
Fix Renovate preset: use github>TryGhost/renovate-config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["@tryghost"]
+  "extends": ["github>TryGhost/renovate-config"]
 }


### PR DESCRIPTION
- Migrate from npm-based preset (`@tryghost`) to GitHub-based (`github>TryGhost/renovate-config`)
- npm presets are deprecated by Renovate
- Fixes: `Preset name not found within published preset config` error