### PR TITLE
Add build and zip steps to CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,4 +19,6 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - run: yarn
+      - run: gulp build
+      - run: gulp zip
       - run: yarn test:ci


### PR DESCRIPTION
- Run `gulp build` and `gulp zip` before `gscan` in CI
- Ensures the theme compiles and packages correctly, not just passes linting