### PR TITLE
Fix gulp-zip v6 ESM compatibility and update to v6.1.0

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,7 @@ const pump = require('pump');
 // gulp plugins and utils
 var livereload = require('gulp-livereload');
 var postcss = require('gulp-postcss');
-var zip = require('gulp-zip');
+var zipModule;
 var uglify = require('gulp-uglify');
 var beeper = require('beeper');
 
@@ -62,7 +62,8 @@ function js(done) {
     ], handleError(done));
 }
 
-function zipper(done) {
+async function zipper(done) {
+    if (!zipModule) { zipModule = (await import('gulp-zip')).default; }
     var targetDir = 'dist/';
     var themeName = require('./package.json').name;
     var filename = themeName + '.zip';
@@ -73,7 +74,7 @@ function zipper(done) {
             '!node_modules', '!node_modules/**',
             '!dist', '!dist/**'
         ]),
-        zip(filename),
+        zipModule(filename),
         dest(targetDir)
     ], handleError(done));
 }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "gulp-uglify": "3.0.2",
     "gulp-util": "3.0.8",
     "gulp-watch": "5.0.1",
-    "gulp-zip": "5.1.0",
+    "gulp-zip": "6.1.0",
     "postcss": "8.5.6",
     "postcss-color-function": "4.1.0",
     "postcss-custom-properties": "15.0.0",


### PR DESCRIPTION
- gulp-zip v6 is pure ESM, which breaks CommonJS `require('gulp-zip')`
- Use dynamic `import()` to load gulp-zip in the gulpfile
- Update gulp-zip 5.1.0 → 6.1.0