### PR TITLE
Remove deprecated ghost-api engine version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "demo": "https://argon.ghost.io",
   "version": "1.0.0",
   "engines": {
-    "ghost": ">=4.0.0",
-    "ghost-api": "v4"
+    "ghost": ">=4.0.0"
   },
   "license": "MIT",
   "screenshots": {


### PR DESCRIPTION
Remove `"ghost-api": "v4"` from package.json engines — gscan warns this is no longer needed.